### PR TITLE
bitcoin-wallet-api Integration Example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1861,6 +1861,19 @@
         "@types/react": "*"
       }
     },
+    "@types/socket.io": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-2.1.4.tgz",
+      "integrity": "sha512-cI98INy7tYnweTsUlp8ocveVdAxENUThO0JsLSCs51cjOP2yV5Mqo5QszMDPckyRRA+PO6+wBgKvGvHUCc23TQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/socket.io-client": {
+      "version": "1.4.32",
+      "resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.32.tgz",
+      "integrity": "sha512-Vs55Kq8F+OWvy1RLA31rT+cAyemzgm0EWNeax6BWF8H7QiiOYMJIdcwSDdm5LVgfEkoepsWkS+40+WNb7BUMbg=="
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -3204,8 +3217,8 @@
       "integrity": "sha512-GzaMlN7pNthrY5BhReVhnfr4Ixx+GUSfyNRHYh0QiMUF0d0+0YaD8MpEdv6AjFBksg/zlqL1fVCBBm6PpTt2Rg=="
     },
     "bchaddrjs-slp": {
-      "version": "git://github.com/simpleledger/bchaddrjs.git#ea05d679783a6737f2f99adc37ebf485dc64f006",
-      "from": "git://github.com/simpleledger/bchaddrjs.git#master",
+      "version": "0.2.8",
+      "resolved": "git://github.com/simpleledger/bchaddrjs.git#ea05d679783a6737f2f99adc37ebf485dc64f006",
       "requires": {
         "bs58check": "^2.1.2",
         "cashaddrjs-slp": "^0.2.12"
@@ -3367,6 +3380,112 @@
         "wif": "^2.0.6"
       }
     },
+    "bitcoin-wallet-api": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/bitcoin-wallet-api/-/bitcoin-wallet-api-0.0.7.tgz",
+      "integrity": "sha512-6lKbR2uDPlaCrIlMwDhSUNO/DJVYslttCwqGVkZhOCIMVMl2M1AOnNp45iBWrlWxjgKYslKIpKbJ2ZQMS9FGpg==",
+      "requires": {
+        "bchaddrjs-slp": "^0.2.8",
+        "bignumber.js": "^9.0.0",
+        "slpjs": "^0.23.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+          "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+          "requires": {
+            "follow-redirects": "1.5.10",
+            "is-buffer": "^2.0.2"
+          }
+        },
+        "bitcore-lib-cash": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/bitcore-lib-cash/-/bitcore-lib-cash-9.0.0.tgz",
+          "integrity": "sha512-u53DJLnjUm/M7NehrzJZAOoLP7mne9Jd1KUFt4xSkQ9vA/NpXgpj5/j7LeR0VzYENNzPkD/fBfXTN+1gbgsRjw==",
+          "requires": {
+            "bitcore-lib": "^9.0.0",
+            "bn.js": "=4.11.8",
+            "bs58": "^4.0.1",
+            "buffer-compare": "=1.1.1",
+            "elliptic": "=6.4.0",
+            "inherits": "=2.0.1",
+            "lodash": "=4.17.15"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "elliptic": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+          "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "slpjs": {
+          "version": "0.23.0",
+          "resolved": "https://registry.npmjs.org/slpjs/-/slpjs-0.23.0.tgz",
+          "integrity": "sha512-nAJQC/JkNvj/RA2vjiMuIneju3huicZASiQhXkzJ1Rc1Bf8fMHKk+877hxB7wTP8gIu820V4nbw33vy2jMtvnQ==",
+          "requires": {
+            "@types/bigi": "^1.4.2",
+            "@types/bip39": "^2.4.2",
+            "@types/lodash": "^4.14.120",
+            "@types/randombytes": "^2.0.0",
+            "@types/socket.io": "^2.1.2",
+            "@types/socket.io-client": "^1.4.32",
+            "@types/wif": "^2.0.1",
+            "axios": "^0.18.1",
+            "bchaddrjs-slp": "0.2.8",
+            "bignumber.js": "^8.1.1",
+            "bitcore-lib-cash": "^9.0.0",
+            "lodash": "^4.17.14"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "8.1.1",
+              "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+              "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
+            }
+          }
+        }
+      }
+    },
     "bitcoincash-ops": {
       "version": "github:Bitcoin-com/bitcoincash-ops#6ab82cc7326c67236f3b2d9d0457258ac2ef48e3",
       "from": "github:Bitcoin-com/bitcoincash-ops#2.0.0"
@@ -3403,6 +3522,41 @@
         "create-hash": "^1.1.2",
         "secp256k1": "^3.0.1",
         "varuint-bitcoin": "^1.0.1"
+      }
+    },
+    "bitcore-lib": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/bitcore-lib/-/bitcore-lib-9.0.0.tgz",
+      "integrity": "sha512-WXg8MXv57xg/WB7WZ/6wj4W1VbRVL83d5taWOKLbxXc6VspwSss6w5DyDJ5YDe1fDyWADjz4fsSU4nCj6jWTgA==",
+      "requires": {
+        "bech32": "=1.1.3",
+        "bn.js": "=4.11.8",
+        "bs58": "^4.0.1",
+        "buffer-compare": "=1.1.1",
+        "elliptic": "=6.4.0",
+        "inherits": "=2.0.1",
+        "lodash": "=4.17.15"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+          "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        }
       }
     },
     "bitcore-lib-cash": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "babel-preset-react-app": "^9.0.2",
     "badger-components-react": "^0.6.0",
     "big.js": "^5.2.2",
+    "bitcoin-wallet-api": "0.0.7",
     "camelcase": "^5.2.0",
     "case-sensitive-paths-webpack-plugin": "2.2.0",
     "core-util-is": "^1.0.2",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -5,8 +5,8 @@ import { Layout, Menu, Icon, Typography, Radio, List, Skeleton } from "antd";
 import Portfolio from "./Portfolio";
 import { ButtonQR } from "badger-components-react";
 import Create from "./Create";
-import Configure from "./Configure";
-import Audit from "./Audit";
+import Send from "./Send";
+import PayDividends from "./PayDividends";
 import NotFound from "./NotFound";
 import "./App.css";
 import { WalletContext } from "../utils/context";
@@ -46,11 +46,11 @@ const App = () => {
       case "0":
         return <Portfolio />;
       case "1":
-        return <Create />;
+        return <Send />;
       case "2":
-        return <Configure />;
+        return <Create />;
       case "3":
-        return <Audit />;
+        return <PayDividends />;
       default:
         return <NotFound />;
     }
@@ -100,87 +100,18 @@ const App = () => {
             >
               <Menu.ItemGroup style={{ marginTop: "0px" }} key="menu" title="MENU">
                 <Menu.Item key="0">
-                  <span>Portfolio</span>
+                  <span>Receive</span>
                 </Menu.Item>
                 <Menu.Item key="1">
-                  <span>Create</span>
+                  <span>Send</span>
                 </Menu.Item>
                 <Menu.Item key="2">
-                  <span>Configure</span>
+                  <span>Create Token</span>
                 </Menu.Item>
                 <Menu.Item key="3">
-                  <span>Audit</span>
+                  <span>Send Dividends</span>
                 </Menu.Item>
               </Menu.ItemGroup>
-
-              {wallet ? (
-                <Menu.ItemGroup key="menu-receive" title="RECEIVE">
-                  <div
-                    style={{
-                      marginLeft: "20px",
-                      paddingTop: "10px"
-                      // display: `${window.innerWidth > 768 ? "none" : null}`
-                    }}
-                  >
-                    <div>
-                      <QRCode
-                        id="borderedQRCode"
-                        address={address === "slpAddress" ? wallet.slpAddress : wallet.cashAddress}
-                      />
-                    </div>
-
-                    <Radio.Group
-                      defaultValue="slpAddress"
-                      // onChange={e => handleChangeAddress(e)}
-                      value={address}
-                      size="small"
-                      buttonStyle="solid"
-                      ref={radio}
-                    >
-                      <Radio.Button
-                        style={{
-                          borderRadius: "19.5px",
-                          height: "40px",
-                          width: "103px"
-                        }}
-                        value="slpAddress"
-                        onClick={e => handleChangeAddress(e)}
-                      >
-                        SLP Tokens
-                      </Radio.Button>
-                      <Radio.Button
-                        style={{
-                          borderRadius: "19.5px",
-                          height: "40px",
-                          width: "103px"
-                        }}
-                        value="cashAddress"
-                        onClick={e => handleChangeAddress(e)}
-                      >
-                        Bitcoin Cash
-                      </Radio.Button>
-                    </Radio.Group>
-                    {/* {!loading ? (
-                  <List
-                    style={{ marginTop: 16 }}
-                    loading={loading}
-                    itemLayout="horizontal"
-                    dataSource={[
-                      {
-                        title: "BCH",
-                        description: balances.balance + balances.unconfirmedBalance || "0"
-                      }
-                    ]}
-                    renderItem={item => (
-                      <List.Item>
-                        <List.Item.Meta title={item.title} description={item.description} />
-                      </List.Item>
-                    )}
-                  />
-                ) : null} */}
-                  </div>
-                </Menu.ItemGroup>
-              ) : null}
             </Menu>
           </Sider>
           <Layout style={{ backgroundColor: "#FBFBFD" }}>

--- a/src/components/Create.js
+++ b/src/components/Create.js
@@ -6,8 +6,9 @@ import { ButtonQR } from "badger-components-react";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import { WalletContext } from "../utils/context";
 import { Input, Button, notification, Spin, Icon, Row, Col, Card, Form, Typography } from "antd";
-import createToken from "../utils/broadcastTransaction";
+// import createToken from "../utils/broadcastTransaction";
 import { QRCode } from "./QRCode";
+import { getAddress, createToken } from "bitcoin-wallet-api";
 
 const { Paragraph, Text } = Typography;
 
@@ -21,10 +22,12 @@ const Create = ({ history }) => {
     tokenSymbol: "",
     documentHash: "",
     documentUri: "",
-    amount: ""
+    amount: "",
+    decimals: "",
+    hasMintBaton: false
   });
 
-  async function handleCreateToken() {
+  function handleCreateToken() {
     setData({
       ...data,
       dirty: false
@@ -35,53 +38,53 @@ const Create = ({ history }) => {
     }
 
     setLoading(true);
-    const { tokenName, tokenSymbol, documentHash, documentUri, amount } = data;
-    try {
-      const docUri = documentUri || "pitico.cash";
-      const link = await createToken(wallet, {
-        name: tokenName,
-        symbol: tokenSymbol,
-        documentHash,
-        docUri,
-        initialTokenQty: amount
-      });
+    const {
+      tokenName,
+      tokenSymbol,
+      documentHash,
+      documentUri,
+      amount,
+      decimals,
+      hasMintBaton
+    } = data;
 
-      notification.success({
-        message: "Success",
-        description: (
-          <a href={link} target="_blank">
-            <Paragraph>Transaction successful. Click or tap here for more details</Paragraph>
-          </a>
-        ),
-        duration: 0
+    getAddress({ protocol: "SLP" })
+      .then(({ address }) => {
+        return createToken({
+          name: tokenName,
+          symbol: tokenSymbol,
+          documentHash,
+          documentUri: documentUri || "pitico.cash",
+          initialSupply: amount,
+          tokenReceiverAddress: address,
+          decimals,
+          batonReceiverAddress: hasMintBaton && address
+        });
+      })
+      .then(({ tokenId }) => {
+        notification.success({
+          message: "Success",
+          description: (
+            <a href={`https://explorer.bitcoin.com/bch/tx/${tokenId}`} target="_blank">
+              <Paragraph>Transaction successful. Click or tap here for more details</Paragraph>
+            </a>
+          ),
+          duration: 0
+        });
+        setLoading(false);
+      })
+      .catch(err => {
+        notification.error({
+          message: `Error: ${err}`
+        });
+        setLoading(false);
       });
-    } catch (e) {
-      let message;
-      switch (e.message) {
-        case "Transaction has no inputs":
-          message = "Insufficient balance";
-          break;
-        case "Document hash must be provided as a 64 character hex string":
-          message = e.message;
-          break;
-        default:
-          message = "Unknown Error, try again later";
-          break;
-      }
-
-      notification.error({
-        message: "Error",
-        description: message
-      });
-    } finally {
-      setLoading(false);
-    }
   }
 
   const handleChange = e => {
-    const { value, name } = e.target;
+    const { value, name, checked, type } = e.target;
 
-    setData(p => ({ ...p, [name]: value }));
+    setData(p => ({ ...p, [name]: type === "checkbox" ? checked : value }));
   };
   return (
     <Row justify="center" type="flex">
@@ -96,20 +99,6 @@ const Create = ({ history }) => {
             }
             bordered={true}
           >
-            <div>
-              {!loadingContext && !balances.balance && !balances.unconfirmedBalance ? (
-                <>
-                  <Paragraph>
-                    <QRCode id="borderedQRCode" address={wallet && wallet.cashAddress} />
-                  </Paragraph>
-                  <Paragraph>You currently have 0 BCH.</Paragraph>
-                  <Paragraph>
-                    Deposit some BCH in order to pay for the transaction that will generate the
-                    token
-                  </Paragraph>
-                </>
-              ) : null}
-            </div>
             <Form>
               <Form.Item
                 validateStatus={!data.dirty && !data.tokenSymbol ? "error" : ""}
@@ -169,6 +158,40 @@ const Create = ({ history }) => {
                   required
                   type="number"
                 />
+              </Form.Item>
+              <Form.Item
+                validateStatus={!data.dirty && Number(data.amount) <= 0 ? "error" : ""}
+                help={
+                  !data.dirty && Number(data.amount) < 0
+                    ? "Should be greater than or equal to 0"
+                    : ""
+                }
+              >
+                <Input
+                  style={{ padding: "0px 20px" }}
+                  placeholder="number of decimal places"
+                  name="decimals"
+                  onChange={e => handleChange(e)}
+                  required
+                  type="number"
+                />
+              </Form.Item>
+              <Form.Item
+                validateStatus={!data.dirty && Number(data.amount) <= 0 ? "error" : ""}
+                help={
+                  !data.dirty && Number(data.amount) < 0
+                    ? "Should be greater than or equal to 0"
+                    : ""
+                }
+              >
+                <Input
+                  style={{ padding: "0px 20px" }}
+                  name="hasMintBaton"
+                  onChange={e => handleChange(e)}
+                  required
+                  type="checkbox"
+                />
+                <span style={{ marginLeft: "16px" }}>Create mint baton</span>
               </Form.Item>
               <div style={{ paddingTop: "12px" }}>
                 <Button onClick={() => handleCreateToken()}>Create Token</Button>

--- a/src/components/OnBoarding.js
+++ b/src/components/OnBoarding.js
@@ -1,84 +1,58 @@
-import React, { useEffect, useState } from "react";
-import styled from "styled-components";
-import { withRouter } from "react-router-dom";
-import { ButtonQR } from "badger-components-react";
-import { CopyToClipboard } from "react-copy-to-clipboard";
-import { WalletContext } from "../utils/context";
-import { Input, Button, notification, Spin, Icon, Row, Col, Card, Form, Typography } from "antd";
+import React, { useState } from "react";
+import { Button, Row, Col, Card } from "antd";
+import { getAddress } from "bitcoin-wallet-api";
 import { QRCode } from "./QRCode";
 
-const { Paragraph, Text } = Typography;
+const SLP = "SLP";
+const BCH = "BCH";
 
 export const OnBoarding = ({ history }) => {
-  const ContextValue = React.useContext(WalletContext);
-  const { wallet, tokens, balance, createWallet } = ContextValue;
-  const [formData, setFormData] = useState({
-    dirty: true,
-    mnemonic: ""
-  });
+  const [error, setError] = useState();
+  const [slpAddress, setSlpAddress] = useState();
+  const [cashAddress, setCashAddress] = useState();
+  const [selection, setSelection] = useState();
 
-  async function submit() {
-    setFormData({
-      ...formData,
-      dirty: false
-    });
-
-    if (!formData.mnemonic) {
-      return;
+  const selectSlp = () => {
+    if (!selection || selection === BCH) {
+      setSelection(SLP);
     }
 
-    createWallet(formData.mnemonic);
-  }
-
-  const handleChange = e => {
-    const { value, name } = e.target;
-
-    setFormData(p => ({ ...p, [name]: value }));
+    getAddress({ protocol: SLP })
+      .then(({ address }) => {
+        setSlpAddress(address);
+      })
+      .catch(err => {
+        setError("There was an error getting the address.");
+      });
   };
+
+  const selectBch = () => {
+    if (!selection || selection === SLP) {
+      setSelection(BCH);
+    }
+
+    getAddress({ protocol: BCH })
+      .then(({ address }) => {
+        setCashAddress(address);
+      })
+      .catch(err => {
+        setError("There was an error getting the address.");
+      });
+  };
+
+  const displayAddress = selection === SLP ? slpAddress : cashAddress;
 
   return (
     <Row gutter={8} justify="center" type="flex">
       <Col lg={8} span={24} style={{ marginTop: 8 }}>
-        <Card
-          title={
-            <h2>
-              <Icon type="plus-square" theme="filled" /> New Wallet
-            </h2>
-          }
-          style={{ height: "100%" }}
-          bordered={false}
-        >
+        <Card title={<h2>Receive</h2>} style={{ height: "100%" }} bordered={false}>
           <div style={{}}>
-            <Button onClick={() => createWallet()}>Create</Button>
+            {error && <div style={{ color: "red" }}>{error}</div>}
+            <Button onClick={() => selectSlp()}>SLP</Button>
+            <Button onClick={() => selectBch()}>BCH</Button>
+
+            {selection && displayAddress && <QRCode id="borderedQRCode" address={displayAddress} />}
           </div>
-        </Card>
-      </Col>
-      <Col lg={8} span={24} style={{ marginTop: 8 }}>
-        <Card
-          title={
-            <h2>
-              <Icon type="import" /> Import Wallet
-            </h2>
-          }
-          bordered={false}
-        >
-          <Form style={{ width: "auto" }}>
-            <Form.Item
-              validateStatus={!formData.dirty && !formData.mnemonic ? "error" : ""}
-              help={!formData.dirty && !formData.mnemonic ? "Should not be empty" : ""}
-            >
-              <Input
-                prefix={<Icon type="lock" />}
-                placeholder="mnemonic"
-                name="mnemonic"
-                onChange={e => handleChange(e)}
-                required
-              />
-            </Form.Item>
-            <div style={{ paddingTop: "12px" }}>
-              <Button onClick={() => submit()}>Import</Button>
-            </div>
-          </Form>
         </Card>
       </Col>
     </Row>

--- a/src/components/Send.js
+++ b/src/components/Send.js
@@ -1,0 +1,194 @@
+import React, { useEffect } from "react";
+import "../index.css";
+import styled from "styled-components";
+import { withRouter } from "react-router-dom";
+import { ButtonQR } from "badger-components-react";
+import { CopyToClipboard } from "react-copy-to-clipboard";
+import { WalletContext } from "../utils/context";
+import {
+  Input,
+  Button,
+  notification,
+  Spin,
+  Icon,
+  Row,
+  Col,
+  Card,
+  Form,
+  Typography,
+  Radio
+} from "antd";
+import createToken from "../utils/broadcastTransaction";
+import { sendAssets } from "bitcoin-wallet-api";
+
+const { Paragraph, Text } = Typography;
+const SLP = "SLP";
+const BCH = "BCH";
+
+const Create = ({ history }) => {
+  const ContextValue = React.useContext(WalletContext);
+  const { wallet, balances, loading: loadingContext } = ContextValue;
+  const [loading, setLoading] = React.useState(false);
+  const radio = React.useRef(null);
+  const [data, setData] = React.useState({
+    dirty: true,
+    receiveAddress: "",
+    protocol: BCH,
+    tokenId: "",
+    amount: null
+  });
+  const [asset, setAsset] = React.useState(BCH);
+  const [txid, setTxid] = React.useState();
+
+  function handleSend() {
+    setData({
+      ...data,
+      dirty: false
+    });
+
+    const { receiveAddress, tokenId, amount } = data;
+    if (!receiveAddress || (asset === SLP && !tokenId) || !amount || Number(amount) <= 0) {
+      return;
+    }
+    setLoading(true);
+    sendAssets({
+      to: receiveAddress,
+      protocol: asset,
+      assetId: tokenId,
+      value: amount
+    })
+      .then(({ txid }) => {
+        setTxid(txid);
+        notification.success({
+          message: "Success",
+          description: (
+            <a href={`https://explorer.bitcoin.com/bch/tx/${txid}`} target="_blank">
+              <Paragraph>Transaction successful. Click or tap here for more details</Paragraph>
+            </a>
+          ),
+          duration: 0
+        });
+        setLoading(false);
+      })
+      .catch(({ description }) => {
+        notification.error({
+          message: "Error",
+          description
+        });
+        setLoading(false);
+      });
+  }
+
+  const handleChange = e => {
+    const { value, name } = e.target;
+
+    setData(p => ({ ...p, [name]: value }));
+  };
+
+  const handleAsset = e => {
+    setAsset(asset === BCH ? SLP : BCH);
+  };
+
+  return (
+    <Row justify="center" type="flex">
+      <Col lg={8} span={24}>
+        <Spin spinning={loading || loadingContext}>
+          <Card
+            style={{ boxShadow: "0px 0px 40px 0px rgba(0,0,0,0.35)", borderRadius: "8px" }}
+            title={
+              <h2>
+                <Icon type="interaction" theme="filled" /> Send
+              </h2>
+            }
+            bordered={true}
+          >
+            <Form>
+              <Form.Item
+                validateStatus={!data.dirty && !data.receiveAddress ? "error" : ""}
+                help={
+                  !data.dirty && !data.receiveAddress
+                    ? "Should be combination of numbers & alphabets"
+                    : ""
+                }
+              >
+                <Input
+                  placeholder={`Receive Address (${asset === BCH ? "cash" : "slp"} address format)`}
+                  name="receiveAddress"
+                  onChange={e => handleChange(e)}
+                  required
+                />
+              </Form.Item>
+              <Form.Item
+                validateStatus={!data.dirty && !data.receiveAddress ? "error" : ""}
+                help={
+                  !data.dirty && !data.receiveAddress
+                    ? "Should be combination of numbers & alphabets"
+                    : ""
+                }
+              >
+                <Radio.Group
+                  defaultValue={BCH}
+                  value={asset}
+                  size="small"
+                  buttonStyle="solid"
+                  ref={radio}
+                >
+                  <Radio.Button
+                    style={{
+                      borderRadius: "19.5px",
+                      height: "40px",
+                      width: "103px"
+                    }}
+                    value={BCH}
+                    onClick={e => handleAsset(e)}
+                  >
+                    BCH
+                  </Radio.Button>
+                  <Radio.Button
+                    style={{
+                      borderRadius: "19.5px",
+                      height: "40px",
+                      width: "103px"
+                    }}
+                    value={SLP}
+                    onClick={e => handleAsset(e)}
+                  >
+                    SLP
+                  </Radio.Button>
+                </Radio.Group>
+              </Form.Item>
+              {asset === SLP && (
+                <Form.Item>
+                  <Input
+                    placeholder="SLP Token ID"
+                    name="tokenId"
+                    onChange={e => handleChange(e)}
+                    required
+                  />
+                </Form.Item>
+              )}
+              <Form.Item
+                validateStatus={!data.dirty && Number(data.amount) <= 0 ? "error" : ""}
+                help={!data.dirty && Number(data.amount) <= 0 ? "Should be greater than 0" : ""}
+              >
+                <Input
+                  style={{ padding: "0px 20px" }}
+                  placeholder="quantity"
+                  name="amount"
+                  onChange={e => handleChange(e)}
+                  required
+                  type="number"
+                />
+              </Form.Item>
+              <div style={{ paddingTop: "12px" }}>
+                <Button onClick={() => handleSend()}>Send</Button>
+              </div>
+            </Form>
+          </Card>
+        </Spin>
+      </Col>
+    </Row>
+  );
+};
+
+export default withRouter(Create);

--- a/src/utils/withSLP.js
+++ b/src/utils/withSLP.js
@@ -2,14 +2,14 @@ import SLPSDK from "slp-sdk";
 
 export default callback => {
   let SLPInstance;
-  if (process.env.REACT_APP_NETWORK === `mainnet`)
-    SLPInstance = new SLPSDK({
-      restURL: window.localStorage.getItem("restAPI") || `https://rest.bitcoin.com/v2/`
-    });
-  else
-    SLPInstance = new SLPSDK({
-      restURL: window.localStorage.getItem("restAPI") || `https://trest.bitcoin.com/v2/`
-    });
+  // if (process.env.REACT_APP_NETWORK === `mainnet`)
+  SLPInstance = new SLPSDK({
+    restURL: `https://rest.bitcoin.com/v2/`
+  });
+  // else
+  //   SLPInstance = new SLPSDK({
+  //     restURL: window.localStorage.getItem("restAPI") || `https://trest.bitcoin.com/v2/`
+  //   });
 
   return (...args) => callback(SLPInstance, ...args);
 };


### PR DESCRIPTION
This is a reference implementation of the bitcoin-wallet-api package for the bitcoin mint app. This PR is meant to serve as an implementation reference only, and should be implemented separately by the core team handling the pitico bitcoin mint dapp.

### Package overview
The bitcoin-wallet-api allows the dapp to get information from the user like their bitcoincash or slp address, and submit transactions (such as send assets or create tokens), without having to hand over their private keys to the dapp. This allows the users to feel more secure when using dapps, and allows dapps to offload development overhead related to user security, transaction formation & broadcasting.

The bitcoin-wallet-api package will serve as a multi provider package, so that dapps can integrate a single package that will connect to various wallets in the ecosystem which are compatible, instead of trying to integrate with each of them separately. This current implementation has the badger chrome extension as the first wallet provider, but more wallet providers will be added in the new future. All that will be required to support these new providers from the dapp side will be to update the bitcoin-wallet-api package version.

The pitico app has been altered from it's original state in this PR to better demonstrate the different methods that the package has to offer. The UX of the app may need to be updated to facilitate a flow where the dapp does not have access to the users private keys. 

To test out this example to get a feel for it working, please make sure to have the badger wallet chrome extension running, and access the site at:
https://bitcoincom-mint-wallet-api-demo.netlify.com/

### getAddress
You can fetch the users slp or cash address.
https://github.com/nickfujita/pitico/blob/bitcoin-wallet-api-demo-diff/src/components/OnBoarding.js

### sendAssets
Send assets to a single address. Can be either slp or bch.
https://github.com/nickfujita/pitico/blob/bitcoin-wallet-api-demo-diff/src/components/Send.js

### payInvoice
Send a BIP70 invoice to the user. This allows the user to know more information about the transaction, and accommodates multiple outputs.
https://github.com/nickfujita/pitico/blob/bitcoin-wallet-api-demo-diff/src/components/PayDividends.js

### createToken
Allows for the creation of new slp tokens.
https://github.com/nickfujita/pitico/blob/bitcoin-wallet-api-demo-diff/src/components/Create.js

Some limitations to be aware of for createToken.
- Creating a token with a baton will always create the mint baton on the BCH change address. In the future, we would like to be able to allow users to set any address to receive the mint baton, but this feature is still in progress.
- Also note, that in the future, we will be looking to provide a `mintToken` method as well, in order to allow users to mint additional tokens with the mint baton using this same wallet api. However this feature has not yet been implemented with our wallet providers.


More info on these methods in the BDIP:
https://github.com/nickfujita/BDIPs/pull/1/files